### PR TITLE
feat: make http_sender public

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -9,7 +9,7 @@ extern crate solana_metrics;
 pub mod blockhash_query;
 pub mod client_error;
 pub mod connection_cache;
-pub(crate) mod http_sender;
+pub mod http_sender;
 pub(crate) mod mock_sender;
 pub mod nonblocking;
 pub mod nonce_utils;


### PR DESCRIPTION
#### Problem

 - required to add prometheus metrics

#### Summary of Changes

 - make http_sender public

